### PR TITLE
# 성능개선시도 대댓글 조회

### DIFF
--- a/board/src/main/java/com/main/board/post/DTO/CreateCommentRequest.java
+++ b/board/src/main/java/com/main/board/post/DTO/CreateCommentRequest.java
@@ -1,0 +1,15 @@
+package com.main.board.post.DTO;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class CreateCommentRequest {
+
+    private long memberId;
+    private Long parentId;
+    private String commentContent;
+}

--- a/board/src/main/java/com/main/board/post/controller/PostController.java
+++ b/board/src/main/java/com/main/board/post/controller/PostController.java
@@ -72,6 +72,14 @@ public class PostController {
     }
     //  join 방식 끝
 
+    // v2방식 join과 비교하기
+    @GetMapping("/findAllComment/{commentId}")
+    public List<MoreCommentResponse> findAllComment(@PathVariable long commentId,
+                                                    @RequestParam(required = false, defaultValue = "0") int page) {
+        long offset = PostUtilMethod.calculateOffsetAndCheckPage(page);
+        return postService.findAllComment(commentId, offset);
+    }
+
     //recursive 방식
     @GetMapping("recursive/{postId}")
     public PostDetailResponse getRecursivePostDetail(@PathVariable long postId,

--- a/board/src/main/java/com/main/board/post/controller/PostController.java
+++ b/board/src/main/java/com/main/board/post/controller/PostController.java
@@ -121,4 +121,12 @@ public class PostController {
         return ResponseEntity.status(HttpStatus.OK).body("게시물이 성공적으로 삭제되었습니다!");
     }
 
+
+    //댓글 생성
+    @PostMapping("/createcomment/{postId}")
+    public ResponseEntity<String> createComment(
+            @RequestBody @Valid CreateCommentRequest createCommentRequest, @PathVariable Long postId) {
+        postService.createComment(createCommentRequest, postId);
+        return ResponseEntity.status(HttpStatus.CREATED).body("댓글이 성공적으로 생성되었습니다!");
+    }
 }

--- a/board/src/main/java/com/main/board/post/repository/PostRepository.java
+++ b/board/src/main/java/com/main/board/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.main.board.post.repository;
 import com.main.board.post.DTO.*;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 
@@ -46,6 +47,15 @@ public interface PostRepository {
     //게시물 이미지 등록
     void createPostImage(@Param("postId") long postId, @Param("filePath") String filePath);
 
+    //logical_Id 가져오기
+    long getLogicalId(long postId);
+    //logical_id 업데이트
+    void updateLogicalId(long postId, long last_logical_id);
+    //commentPath 가져오기
+    String getCommentPath(long postId, long parentId);
 
-
+    //댓글 작성(원댓글)
+    void createParentComment(@Param("createCommentRequest") CreateCommentRequest createCommentRequest,@Param("last_logical_id") long last_logical_id ,@Param("postId") long postId);
+    //댓글 작성(대댓글)
+    void createChildComment(@Param("createCommentRequest") CreateCommentRequest createCommentRequest,@Param("last_logical_id") long last_logical_id,@Param("postId") long postId,@Param("commentPath") String commentPath);
 }

--- a/board/src/main/java/com/main/board/post/repository/PostRepository.java
+++ b/board/src/main/java/com/main/board/post/repository/PostRepository.java
@@ -27,6 +27,11 @@ public interface PostRepository {
     List<CommentDetailFromDB> getRecursiveCommentList(long postId, long offset);
     List<CommentDetailFromDB> getRecursiveMoreCommentList(long commentId, long offset, long postId);
 
+    //댓글 성능 튜닝
+    //1. path가져오기
+    long findByPath(long commentId);
+    List<CommentDetailFromDB> findAllComment(long parentPath, long postId, long offset);
+
     //게시물 작성 ceate
     void createPost(CreatePostRequest createPostRequest);
     //게시물 수정 update

--- a/board/src/main/java/com/main/board/post/repository/PostRepository.java
+++ b/board/src/main/java/com/main/board/post/repository/PostRepository.java
@@ -29,7 +29,7 @@ public interface PostRepository {
 
     //댓글 성능 튜닝
     //1. path가져오기
-    long findByPath(long commentId);
+    long getPathByCommentId(long commentId);
     List<CommentDetailFromDB> findAllComment(long parentPath, long postId, long offset);
 
     //게시물 작성 ceate

--- a/board/src/main/java/com/main/board/post/service/PostService.java
+++ b/board/src/main/java/com/main/board/post/service/PostService.java
@@ -193,7 +193,7 @@ public class PostService {
 
     public List<MoreCommentResponse> findAllComment(long commentId, long offset) {
         // 1. 부모댓글의 path값 가져오기
-        long parentPath = postRepository.findByPath(commentId);
+        long parentPath = postRepository.getPathByCommentId(commentId);
         // 2. postId 가져오기
         long postId = postRepository.findByPostId(commentId);
         //3. 부모댓글의 path값을 통해 자식 댓글 가져오기

--- a/board/src/main/resources/mappers/PostMapper.xml
+++ b/board/src/main/resources/mappers/PostMapper.xml
@@ -255,4 +255,36 @@
         VALUES (#{postId}, #{filePath}, now());
     </insert>
 
+    <select id="getLogicalId" parameterType="long" resultType="long">
+        SELECT last_logical_id
+        FROM post
+        WHERE id = #{postId}
+        FOR UPDATE
+    </select>
+
+    <update id="updateLogicalId" parameterType="long">
+        UPDATE post
+        SET last_logical_id = #{last_logical_id}
+        WHERE id = #{postId}
+    </update>
+
+    <select id="getCommentPath" parameterType="long" resultType="String">
+        SELECT comment_path
+        FROM comment
+        WHERE post_id = #{postId}
+        AND id = #{parentId}
+    </select>
+
+    <insert id="createParentComment" parameterType="map">
+        INSERT INTO comment (member_id, post_id,logical_id, comment_path,comment_content, create_at)
+        VALUES (#{createCommentRequest.memberId}, #{postId},#{last_logical_id}, #{last_logical_id}, #{createCommentRequest.commentContent}, now());
+    </insert>
+
+    <insert id="createChildComment" parameterType="map">
+        INSERT INTO comment (member_id, post_id, parent_id, logical_id, comment_path, comment_content, create_at)
+        VALUES (#{createCommentRequest.memberId}, #{postId}, #{createCommentRequest.parentId},#{last_logical_id}, #{commentPath}, #{createCommentRequest.commentContent}, now());
+    </insert>
+
+
+
 </mapper>

--- a/board/src/main/resources/mappers/PostMapper.xml
+++ b/board/src/main/resources/mappers/PostMapper.xml
@@ -92,6 +92,11 @@
             LIMIT #{offset}, 10
     </select>
 
+    <select id="findByPath" parameterType="Long" resultType="Long">
+        SELECT c.comment_path
+        FROM comment c
+        WHERE c.id = #{commentId}
+    </select>
 
     <select id="getJoinMoreCommentList" parameterType="Long" resultType="com.main.board.post.DTO.CommentDetailFromDB">
         SELECT
@@ -191,6 +196,24 @@
         FROM comment_tree ct
         WHERE ct.parentid IS NOT NULL
         ORDER BY ct.createdAt ASC
+        LIMIT #{offset}, 10
+    </select>
+
+    <select id="findAllComment" parameterType="Long" resultType="com.main.board.post.DTO.CommentDetailFromDB">
+        SELECT  c.id as commentId,
+                c.comment_content as commentContent,
+                c.create_at as createdAt,
+                c.comment_like as likeCount,
+                c.parent_id as parentId,
+                m.email as email,
+                CASE WHEN COUNT(c2.id) > 0 THEN true ELSE false END AS hasChild
+        FROM comment c
+        join member m on c.member_id = m.id
+        left join comment c2 on c.id = c2.parent_id
+        WHERE c.post_id = #{postId}
+          AND c.comment_path LIKE CONCAT(#{parentPath}, '/%')
+        GROUP BY c.id
+        ORDER BY c.create_at ASC
         LIMIT #{offset}, 10
     </select>
 

--- a/board/src/main/resources/mappers/PostMapper.xml
+++ b/board/src/main/resources/mappers/PostMapper.xml
@@ -92,7 +92,7 @@
             LIMIT #{offset}, 10
     </select>
 
-    <select id="findByPath" parameterType="Long" resultType="Long">
+    <select id="getPathByCommentId" parameterType="Long" resultType="Long">
         SELECT c.comment_path
         FROM comment c
         WHERE c.id = #{commentId}


### PR DESCRIPTION
1. 기존 join문 
![image](https://github.com/user-attachments/assets/e51d0dd1-477b-4847-921a-8d869bcb97d8)

2. DB구조 바꾼후 조회쿼리문
![image](https://github.com/user-attachments/assets/40d83120-6247-4048-b90c-8ad6a113a4cc)

차이점
DB콘솔창에서의 속도는
1. 기존 join문은 대략 1초
2. 개선한 쿼리문의 경우 0.4초

포스트맨에서 확인시에는 
1. 기존 join문
![image](https://github.com/user-attachments/assets/dd0e3f8e-fdae-4f5a-9570-59ef421c8b50)

2. 개선한 쿼리문
![image](https://github.com/user-attachments/assets/38fc8117-2e87-4f9e-abe4-497b4f7b6988)

포스트맨에서 속도는 기존 대비 약 8.4배 성능 향상
DB콘솔기준 2.5배 향상
